### PR TITLE
Add fixed rubocop offenses, refactored end_time

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,9 +1,7 @@
-require "google/apis/calendar_v3"
-require "google/api_client/client_secrets.rb"
+require 'google/apis/calendar_v3'
+require 'google/api_client/client_secrets.rb'
 
 class InvitationsController < ApplicationController
-  CALENDAR_ID = 'primary'
-
   def create
     client = get_google_calendar_client(current_user)
 
@@ -23,20 +21,21 @@ class InvitationsController < ApplicationController
 
   def get_google_calendar_client(current_user)
     client = Google::Apis::CalendarV3::CalendarService.new
-    return unless (current_user.present? && current_user.token.present? && current_user.refresh_token.present?)
+    return unless current_user.present? && current_user.token.present? && current_user.refresh_token.present?
+
     secrets = Google::APIClient::ClientSecrets.new({
-      "web" => {
-        "access_token" => current_user.token,
-        "refresh_token" => current_user.refresh_token,
-        "client_id" => ENV["GOOGLE_API_KEY"],
-        "client_secret" => ENV["GOOGLE_API_SECRET"]
+      'web' => {
+        'access_token' => current_user.token,
+        'refresh_token' => current_user.refresh_token,
+        'client_id' => ENV['GOOGLE_API_KEY'],
+        'client_secret' => ENV['GOOGLE_API_SECRET']
       }
     })
     begin
       client.authorization = secrets.to_authorization
-      client.authorization.grant_type = "refresh_token"
+      client.authorization.grant_type = 'refresh_token'
 
-      if !current_user.present?
+      unless current_user.present?
         client.authorization.refresh!
         current_user.update_attributes(
           access_token: client.authorization.token,
@@ -54,13 +53,13 @@ class InvitationsController < ApplicationController
   private
 
   def get_viewing_party(viewing_party)
-    year, month, day = viewing_party.start_time.to_s.split(" ")[0].split("-").map(&:to_i)
-    hour, minute = viewing_party.start_time.to_s.split(" ")[1].split(":")[0..1].map(&:to_i)
-    start_time = DateTime.new(year, month, day, hour, minute, 0, "-06:00")
+    year, month, day = viewing_party.start_time.to_s.split(' ')[0].split('-').map(&:to_i)
+    hour, minute = viewing_party.start_time.to_s.split(' ')[1].split(':')[0..1].map(&:to_i)
+    start_time = DateTime.new(year, month, day, hour, minute, 0, '-06:00')
 
-    year, month, day = viewing_party.end_time.to_s.split(" ")[0].split("-").map(&:to_i)
-    hour, minute = viewing_party.end_time.to_s.split(" ")[1].split(":")[0..1].map(&:to_i)
-    end_time = DateTime.new(year, month, day, hour, minute, 0, "-06:00")
+    year, month, day = viewing_party.end_time.to_s.split(' ')[0].split('-').map(&:to_i)
+    hour, minute = viewing_party.end_time.to_s.split(' ')[1].split(':')[0..1].map(&:to_i)
+    end_time = DateTime.new(year, month, day, hour, minute, 0, '-06:00')
 
     event = Google::Apis::CalendarV3::Event.new({
       summary: viewing_party[:movie_title],
@@ -85,10 +84,10 @@ class InvitationsController < ApplicationController
       },
       notification_settings: {
         notifications: [
-                        {type: 'event_creation', method: 'email'},
-                        {type: 'event_change', method: 'email'},
-                        {type: 'event_cancellation', method: 'email'},
-                        {type: 'event_response', method: 'email'}
+                        { type: 'event_creation', method: 'email' },
+                        { type: 'event_change', method: 'email' },
+                        { type: 'event_cancellation', method: 'email' },
+                        { type: 'event_response', method: 'email' }
                        ]
       }, 'primary': true
     })

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -26,7 +26,7 @@
       <% party = Party.find_by(id: invitation.party_id) %>
       <h5>Movie Title: <%= party.movie_title %></h5>
       <p>Date and Time: <%= party.start_time %></p>
-      <%= link_to "Add to Calendar", "/invitations?party_id=#{invitation.party_id}&invitation_id=#{invitation.id}",  method: :post %>
+      <%= link_to "Add to Calendar", "/parties?party_id=#{invitation.party_id}&invitation_id=#{invitation.id}",  method: :post %>
     <% end %>
   </section>
   <section class="created">

--- a/db/migrate/20200826164110_change_time_name.rb
+++ b/db/migrate/20200826164110_change_time_name.rb
@@ -1,5 +1,0 @@
-class ChangeTimeName < ActiveRecord::Migration[5.2]
-  def change
-    rename_column :parties, :time, :end_time
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_26_164110) do
+ActiveRecord::Schema.define(version: 2020_08_25_212829) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/features/dashboard/dashboard_spec.rb
+++ b/spec/features/dashboard/dashboard_spec.rb
@@ -30,10 +30,13 @@ RSpec.describe 'user dashboard page' do
     viewing_party_1 = jessye.parties.create(
       movie_title: 'Spirited Away',
       duration_of_party: '125',
-      friend_ids: ["#{current_user.id}"],
-      start_time: "2020-09-03T18:24",
+      friend_ids: [current_user.id],
+      start_time: "2020-09-03T18:24"
     )
 
+    visit '/dashboard'
+
+    save_and_open_page
     within '.invitations' do
       expect(page).to have_content('Spirited Away')
       expect(page).to have_content('Thu, 03 Sept 2020 18:24:00 UTC +00:00,')
@@ -55,7 +58,7 @@ RSpec.describe 'user dashboard page' do
       click_on 'Create Viewing Party'
 
       fill_in 'Duration of party', with: 200
-      fill_in 'Date', with: '2020-08-29'
+      fill_in 'Date and time', with: '2020-08-29'
       fill_in 'Time', with: '18:00'
       check('friend_ids[]', match: :first)
 


### PR DESCRIPTION
- An invitee is now routed to the `PartiesController`, so the `InvitationsController` is unecessary
- Refactored methods within the `PartiesController`
- Corrected most Rubocop offenses